### PR TITLE
Tams work part2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 14)
 find_package(termcolor REQUIRED)
 include_directories(SYSTEM ${termcolor_INCLUDE_DIRS})
 
-include_directories(source)
+include_directories(source lib)
 
 add_executable(${PROJECT_NAME}
     source/Car.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.10)
+project(part1)
+
+set(CMAKE_CXX_COMPILER /usr/bin/g++)
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(termcolor REQUIRED)
+include_directories(SYSTEM ${termcolor_INCLUDE_DIRS})
+
+include_directories(source)
+
+add_executable(${PROJECT_NAME}
+    source/Car.cpp
+    source/FuelGauge.cpp
+    source/Logger.cpp
+    source/main.cpp
+)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Given the source code in this folder:
 1. Attach a screenshot of the output to the pull request
 
 ## Part 2
-TBD
+After you have completed part 1, a team member will push changes to a branch called *SupportColorfulLogging*. It seems while you were making these changes for our "customer", your team member made similar changes to solve the problem. We need to get on the same page!
+1. Create a new branch from the tip of your existing branch
+1. Merge the *SupportColorfulLogging* branch into your new branch
+1. Preserve the new Logger classes (but feel free to suggest improvements)
+1. Ensure there are no regressions
+1. Commit your changes and open a pull request
+1. Attach a screenshot of the output to the pull request
+1. Await instructions for Part 3
 
 ## Part 3
 TBD

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+$script = <<SCRIPT
+    apt update
+    apt install -y tree tmux gcc g++ make cmake
+
+    pushd /tmp
+    wget -qO- https://github.com/ikalnytskyi/termcolor/archive/refs/tags/v2.1.0.tar.gz | tar xz
+    mkdir termcolor_build
+    pushd termcolor_build
+    cmake ../termcolor-2.1.0 && make
+    make install
+    popd
+    popd
+    rm -rf /tmp/termcolor-2.1.0 /tmp/termcolor_build
+
+SCRIPT
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "geerlingguy/ubuntu1804"
+    config.ssh.shell = "bash"
+    config.vm.define "devenv" do |devenv|
+        devenv.vm.provision "shell", inline: $script
+    end
+end

--- a/lib/termcolor.hpp
+++ b/lib/termcolor.hpp
@@ -1,0 +1,663 @@
+//!
+//! termcolor
+//! ~~~~~~~~~
+//!
+//! termcolor is a header-only c++ library for printing colored messages
+//! to the terminal. Written just for fun with a help of the Force.
+//!
+//! :copyright: (c) 2013 by Ihor Kalnytskyi
+//! :license: BSD, see LICENSE for details
+//!
+
+#ifndef TERMCOLOR_HPP_
+#define TERMCOLOR_HPP_
+
+// the following snippet of code detects the current OS and
+// defines the appropriate macro that is used to wrap some
+// platform specific things
+#if defined(_WIN32) || defined(_WIN64)
+#   define TERMCOLOR_OS_WINDOWS
+#elif defined(__APPLE__)
+#   define TERMCOLOR_OS_MACOS
+#elif defined(__unix__) || defined(__unix)
+#   define TERMCOLOR_OS_LINUX
+#else
+#   error unsupported platform
+#endif
+
+
+// This headers provides the `isatty()`/`fileno()` functions,
+// which are used for testing whether a standart stream refers
+// to the terminal. As for Windows, we also need WinApi funcs
+// for changing colors attributes of the terminal.
+#if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+#   include <unistd.h>
+#elif defined(TERMCOLOR_OS_WINDOWS)
+#   include <io.h>
+#   include <windows.h>
+#endif
+
+
+#include <iostream>
+#include <cstdio>
+
+
+namespace termcolor
+{
+    // Forward declaration of the `_internal` namespace.
+    // All comments are below.
+    namespace _internal
+    {
+        // An index to be used to access a private storage of I/O streams. See
+        // colorize / nocolorize I/O manipulators for details.
+        static int colorize_index = std::ios_base::xalloc();
+
+        inline FILE* get_standard_stream(const std::ostream& stream);
+        inline bool is_colorized(std::ostream& stream);
+        inline bool is_atty(const std::ostream& stream);
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
+    #endif
+    }
+
+    inline
+    std::ostream& colorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 1L;
+        return stream;
+    }
+
+    inline
+    std::ostream& nocolorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 0L;
+        return stream;
+    }
+
+    inline
+    std::ostream& reset(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[00m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1, -1);
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& bold(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[1m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& dark(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[2m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& italic(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[3m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& underline(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[4m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1, COMMON_LVB_UNDERSCORE);
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& blink(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[5m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& reverse(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[7m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& concealed(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[8m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& crossed(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[9m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    template <uint8_t code> inline
+    std::ostream& color(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            char command[12];
+            std::snprintf(command, sizeof(command), "\033[38;5;%dm", code);
+            stream << command;
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    template <uint8_t code> inline
+    std::ostream& on_color(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            char command[12];
+            std::snprintf(command, sizeof(command), "\033[48;5;%dm", code);
+            stream << command;
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    template <uint8_t r, uint8_t g, uint8_t b> inline
+    std::ostream& color(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            char command[20];
+            std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", r, g, b);
+            stream << command;
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    template <uint8_t r, uint8_t g, uint8_t b> inline
+    std::ostream& on_color(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            char command[20];
+            std::snprintf(command, sizeof(command), "\033[48;2;%d;%d;%dm", r, g, b);
+            stream << command;
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[30m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[31m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[32m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[33m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[34m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[35m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[36m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[37m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+
+
+    inline
+    std::ostream& on_grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[40m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[41m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[42m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[43m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[44m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[45m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[46m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[47m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+
+        return stream;
+    }
+
+
+    class rgb
+    {
+    public:
+	    rgb(uint8_t r_, uint8_t g_, uint8_t b_)
+	    	: r(r_)
+	    	, g(g_)
+	    	, b(b_)
+	    {
+	    }
+	    friend std::ostream& operator<<(std::ostream& stream, rgb const& color)
+	    {
+	        if (_internal::is_colorized(stream))
+	        {
+	        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+	            char command[20];
+	            std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", color.r, color.g, color.b);
+	            stream << command;
+	        #elif defined(TERMCOLOR_OS_WINDOWS)
+	        #endif
+	        }
+	        return stream;
+	    }
+
+		uint8_t r;
+		uint8_t g;
+		uint8_t b;
+    };
+
+    //! Since C++ hasn't a way to hide something in the header from
+    //! the outer access, I have to introduce this namespace which
+    //! is used for internal purpose and should't be access from
+    //! the user code.
+    namespace _internal
+    {
+        //! Since C++ hasn't a true way to extract stream handler
+        //! from the a given `std::ostream` object, I have to write
+        //! this kind of hack.
+        inline
+        FILE* get_standard_stream(const std::ostream& stream)
+        {
+            if (&stream == &std::cout)
+                return stdout;
+            else if ((&stream == &std::cerr) || (&stream == &std::clog))
+                return stderr;
+
+            return nullptr;
+        }
+
+        // Say whether a given stream should be colorized or not. It's always
+        // true for ATTY streams and may be true for streams marked with
+        // colorize flag.
+        inline
+        bool is_colorized(std::ostream& stream)
+        {
+            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index));
+        }
+
+        //! Test whether a given `std::ostream` object refers to
+        //! a terminal.
+        inline
+        bool is_atty(const std::ostream& stream)
+        {
+            FILE* std_stream = get_standard_stream(stream);
+
+            // Unfortunately, fileno() ends with segmentation fault
+            // if invalid file descriptor is passed. So we need to
+            // handle this case gracefully and assume it's not a tty
+            // if standard stream is not detected, and 0 is returned.
+            if (!std_stream)
+                return false;
+
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            return ::isatty(fileno(std_stream));
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            return ::_isatty(_fileno(std_stream));
+        #endif
+        }
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        //! Change Windows Terminal colors attribute. If some
+        //! parameter is `-1` then attribute won't changed.
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background)
+        {
+            // yeah, i know.. it's ugly, it's windows.
+            static WORD defaultAttributes = 0;
+
+            // Windows doesn't have ANSI escape sequences and so we use special
+            // API to change Terminal output color. That means we can't
+            // manipulate colors by means of "std::stringstream" and hence
+            // should do nothing in this case.
+            if (!_internal::is_atty(stream))
+                return;
+
+            // get terminal handle
+            HANDLE hTerminal = INVALID_HANDLE_VALUE;
+            if (&stream == &std::cout)
+                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
+            else if (&stream == &std::cerr)
+                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
+
+            // save default terminal attributes if it unsaved
+            if (!defaultAttributes)
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                    return;
+                defaultAttributes = info.wAttributes;
+            }
+
+            // restore all default settings
+            if (foreground == -1 && background == -1)
+            {
+                SetConsoleTextAttribute(hTerminal, defaultAttributes);
+                return;
+            }
+
+            // get current settings
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                return;
+
+            if (foreground != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0x0F);
+                info.wAttributes |= static_cast<WORD>(foreground);
+            }
+
+            if (background != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0xF0);
+                info.wAttributes |= static_cast<WORD>(background);
+            }
+
+            SetConsoleTextAttribute(hTerminal, info.wAttributes);
+        }
+    #endif // TERMCOLOR_OS_WINDOWS
+
+    } // namespace _internal
+
+} // namespace termcolor
+
+
+#undef TERMCOLOR_OS_WINDOWS
+#undef TERMCOLOR_OS_MACOS
+#undef TERMCOLOR_OS_LINUX
+
+#endif // TERMCOLOR_HPP_

--- a/source/Car.cpp
+++ b/source/Car.cpp
@@ -1,7 +1,9 @@
+#include <memory>
+
 #include "Car.h"
 
 Car::Car()
-	: logger(new Logger())
+	: logger(std::make_shared<Logger<LogLevel::info>>())
 {
 }
 void Car::TurnLeft()

--- a/source/Car.cpp
+++ b/source/Car.cpp
@@ -3,8 +3,7 @@
 #include "Car.h"
 
 Car::Car()
-	: fuelGauge()
-	, logger(std::make_shared<Logger<LogLevel::info>>())
+	: logger(new BlueLogger())
 {
 }
 void Car::TurnLeft()

--- a/source/Car.cpp
+++ b/source/Car.cpp
@@ -3,7 +3,8 @@
 #include "Car.h"
 
 Car::Car()
-	: logger(std::make_shared<Logger<LogLevel::info>>())
+	: fuelGauge()
+	, logger(std::make_shared<Logger<LogLevel::info>>())
 {
 }
 void Car::TurnLeft()

--- a/source/Car.h
+++ b/source/Car.h
@@ -1,4 +1,7 @@
-#pragma once
+#ifndef SOURCE_CAR_H
+#define SOURCE_CAR_H
+
+#include <memory>
 
 #include "FuelGauge.h"
 #include "Logger.h"
@@ -12,5 +15,7 @@ public:
 	void Accelerate();
 private:
 	FuelGauge fuelGauge;
-	ILogger* logger;
+	std::shared_ptr<ILogger> logger;
 };
+
+#endif // SOURCE_CAR_H

--- a/source/FuelGauge.cpp
+++ b/source/FuelGauge.cpp
@@ -1,8 +1,10 @@
+#include <memory>
+
 #include "FuelGauge.h"
 
 FuelGauge::FuelGauge()
 	: fuelLevel(5)
-	, logger(new Logger())
+	, logCritical(std::make_shared<Logger<LogLevel::critical>>())
 {
 }
 void FuelGauge::DecrementFuelLevel()
@@ -10,6 +12,6 @@ void FuelGauge::DecrementFuelLevel()
 	--fuelLevel;
 	if (fuelLevel < 2)
 	{
-		logger->Log("Low fuel!");
+		logCritical->Log("Low fuel!");
 	}
 }

--- a/source/FuelGauge.cpp
+++ b/source/FuelGauge.cpp
@@ -4,7 +4,7 @@
 
 FuelGauge::FuelGauge()
 	: fuelLevel(5)
-	, logCritical(std::make_shared<Logger<LogLevel::critical>>())
+	, logger(new RedLogger())
 {
 }
 void FuelGauge::DecrementFuelLevel()
@@ -12,6 +12,6 @@ void FuelGauge::DecrementFuelLevel()
 	--fuelLevel;
 	if (fuelLevel < 2)
 	{
-		logCritical->Log("Low fuel!");
+		logger->Log("Low fuel!");
 	}
 }

--- a/source/FuelGauge.h
+++ b/source/FuelGauge.h
@@ -12,7 +12,7 @@ public:
 	void DecrementFuelLevel();
 private:
 	int fuelLevel;
-	std::shared_ptr<ILogger> logCritical;
+	ILogger* logger;
 };
 
 #endif // SOURCE_FUELGAUGE_H

--- a/source/FuelGauge.h
+++ b/source/FuelGauge.h
@@ -1,4 +1,7 @@
-#pragma once
+#ifndef SOURCE_FUELGAUGE_H
+#define SOURCE_FUELGAUGE_H
+
+#include <memory>
 
 #include "Logger.h"
 
@@ -9,5 +12,7 @@ public:
 	void DecrementFuelLevel();
 private:
 	int fuelLevel;
-	ILogger* logger;
+	std::shared_ptr<ILogger> logCritical;
 };
+
+#endif // SOURCE_FUELGAUGE_H

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -2,7 +2,18 @@
 
 #include <iostream>
 
-void Logger::Log(std::string string)
+template<LogLevel lvl>
+Logger<lvl>::Logger(): logLevel(lvl) {}
+
+template<LogLevel lvl>
+void Logger<lvl>::Log(std::string string)
 {
-	std::cout << string << std::endl;
+	if(logLevel == LogLevel::info) {
+		std::cout << termcolor::blue << string << std::endl;
+	} else if(logLevel == LogLevel::critical) {
+		std::cout << termcolor::red << string << std::endl;
+	}
 }
+
+template class Logger<LogLevel::info>;
+template class Logger<LogLevel::critical>;

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -1,19 +1,18 @@
 #include "Logger.h"
 
+#include "termcolor.hpp"
 #include <iostream>
 
-template<LogLevel lvl>
-Logger<lvl>::Logger(): logLevel(lvl) {}
-
-template<LogLevel lvl>
-void Logger<lvl>::Log(std::string string)
+void Logger::Log(std::string string)
 {
-	if(logLevel == LogLevel::info) {
-		std::cout << termcolor::blue << string << std::endl;
-	} else if(logLevel == LogLevel::critical) {
-		std::cout << termcolor::red << string << std::endl;
-	}
+	std::cout << string << std::endl;
 }
 
-template class Logger<LogLevel::info>;
-template class Logger<LogLevel::critical>;
+void BlueLogger::Log(std::string string)
+{
+	std::cout << termcolor::blue << string << std::endl;
+}
+void RedLogger::Log(std::string string)
+{
+	std::cout << termcolor::red << string << std::endl;
+}

--- a/source/Logger.h
+++ b/source/Logger.h
@@ -12,12 +12,21 @@ struct ILogger
 	virtual void Log(std::string string) = 0;
 };
 
-template<LogLevel lvl>
 class Logger : public ILogger
 {
-	LogLevel logLevel;
 public:
-	Logger();
+	void Log(std::string string);
+};
+
+class BlueLogger : public ILogger
+{
+public:
+	void Log(std::string string);
+};
+
+class RedLogger : public ILogger
+{
+public:
 	void Log(std::string string);
 };
 

--- a/source/Logger.h
+++ b/source/Logger.h
@@ -1,14 +1,24 @@
-#pragma once
+#ifndef SOURCE_LOGGER_H
+#define SOURCE_LOGGER_H
 
 #include <string>
+
+#include <termcolor/termcolor.hpp>
+
+enum class LogLevel{info, critical};
 
 struct ILogger
 {
 	virtual void Log(std::string string) = 0;
 };
 
+template<LogLevel lvl>
 class Logger : public ILogger
 {
+	LogLevel logLevel;
 public:
+	Logger();
 	void Log(std::string string);
 };
+
+#endif // SOURCE_LOGGER_H

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, char* argv[])
 {
-	Logger<LogLevel::info> logger;
+	Logger logger;
 
 	logger.Log("Starting application");
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,9 +1,10 @@
+
 #include "Car.h"
 #include "Logger.h"
 
 int main(int argc, char* argv[])
 {
-	Logger logger;
+	Logger<LogLevel::info> logger;
 
 	logger.Log("Starting application");
 


### PR DESCRIPTION
This branch was created from the tip of branch tams_work_part1, and then branch SupportColorfulLogging was merged into this branch. All of the new Logger classes and functionality essence from SupportColorfulLogging is preserved. This is purposely done to illustrate an output logger color fault that exists in the SupportColorfulLogging branch.