### PR TITLE
Tams work part3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
-project(part1)
+project(part3)
 
 set(CMAKE_CXX_COMPILER /usr/bin/g++)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(termcolor REQUIRED)
 include_directories(SYSTEM ${termcolor_INCLUDE_DIRS})

--- a/source/Car.cpp
+++ b/source/Car.cpp
@@ -2,9 +2,18 @@
 
 #include "Car.h"
 
-Car::Car()
-	: logger(new BlueLogger())
+Car::Car(LogColor c)
+	: logColor(std::move(c))
+	, fuelGauge()
+	, logger(nullptr)
 {
+	if(logColor == LogColor::cyan) {
+		logger = std::make_shared<Logger<LogColor::cyan>>();
+	} else if(logColor == LogColor::magenta) {
+		logger = std::make_shared<Logger<LogColor::magenta>>();
+	} else {
+		logger = std::make_shared<Logger<LogColor::white>>();
+	}
 }
 void Car::TurnLeft()
 {

--- a/source/Car.h
+++ b/source/Car.h
@@ -8,12 +8,14 @@
 
 class Car
 {
+	
 public:
-	Car();
+	Car(LogColor c);
 	void TurnLeft();
 	void TurnRight();
 	void Accelerate();
 private:
+	const LogColor logColor;
 	FuelGauge fuelGauge;
 	std::shared_ptr<ILogger> logger;
 };

--- a/source/FuelGauge.cpp
+++ b/source/FuelGauge.cpp
@@ -4,7 +4,7 @@
 
 FuelGauge::FuelGauge()
 	: fuelLevel(5)
-	, logger(new RedLogger())
+	, logYellow(std::make_shared<Logger<LogColor::yellow>>())
 {
 }
 void FuelGauge::DecrementFuelLevel()
@@ -12,6 +12,6 @@ void FuelGauge::DecrementFuelLevel()
 	--fuelLevel;
 	if (fuelLevel < 2)
 	{
-		logger->Log("Low fuel!");
+		logYellow->Log("Low fuel!");
 	}
 }

--- a/source/FuelGauge.h
+++ b/source/FuelGauge.h
@@ -12,7 +12,7 @@ public:
 	void DecrementFuelLevel();
 private:
 	int fuelLevel;
-	ILogger* logger;
+	std::shared_ptr<ILogger> logYellow;
 };
 
 #endif // SOURCE_FUELGAUGE_H

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -3,10 +3,34 @@
 #include "termcolor.hpp"
 #include <iostream>
 
-void Logger::Log(std::string string)
+template<LogColor c>
+Logger<c>::Logger(): logColor(c) {}
+
+template<LogColor c>
+void Logger<c>::Log(std::string string)
 {
-	std::cout << string << std::endl;
+	if(logColor == LogColor::white) {
+		std::cout << termcolor::white;
+	} else if(logColor == LogColor::red) {
+		std::cout << termcolor::red;
+	} else if(logColor == LogColor::blue) {
+		std::cout << termcolor::blue;
+	} else if(logColor == LogColor::yellow) {
+		std::cout << termcolor::yellow;
+	} else if(logColor == LogColor::cyan) {
+		std::cout << termcolor::cyan;
+	} else if(logColor == LogColor::magenta) {
+		std::cout << termcolor::magenta;
+	}
+	std::cout << string << termcolor::reset << std::endl;
 }
+
+template class Logger<LogColor::white>;
+template class Logger<LogColor::red>;
+template class Logger<LogColor::blue>;
+template class Logger<LogColor::yellow>;
+template class Logger<LogColor::cyan>;
+template class Logger<LogColor::magenta>;
 
 void BlueLogger::Log(std::string string)
 {

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 template<LogColor c>
-Logger<c>::Logger(): logColor(c) {}
+Logger<c>::Logger(): logColor(std::move(c)) {}
 
 template<LogColor c>
 void Logger<c>::Log(std::string string)

--- a/source/Logger.h
+++ b/source/Logger.h
@@ -2,19 +2,21 @@
 #define SOURCE_LOGGER_H
 
 #include <string>
-
 #include <termcolor/termcolor.hpp>
 
-enum class LogLevel{info, critical};
+enum class LogColor{white, red, blue, yellow, cyan, magenta};
 
 struct ILogger
 {
 	virtual void Log(std::string string) = 0;
 };
 
+template<LogColor c>
 class Logger : public ILogger
 {
+	LogColor logColor;
 public:
+Logger();
 	void Log(std::string string);
 };
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -4,14 +4,18 @@
 
 int main(int argc, char* argv[])
 {
-	Logger logger;
+	Logger<LogColor::white> logger;
 
 	logger.Log("Starting application");
 
-	Car car;
-	car.TurnLeft();
-	car.TurnRight();
-	car.Accelerate();
+	Car car1(LogColor::cyan);
+	Car car2(LogColor::magenta);
+	car1.TurnLeft();
+	car2.TurnLeft();
+	car1.TurnRight();
+	car2.TurnRight();
+	car1.Accelerate();
+	car2.Accelerate();
 
 	logger.Log("Exiting application");
 }


### PR DESCRIPTION
This update changes previous implementation from branch `tams_work_part1_with_SupportColorfulLogging` to using only templated Logger class, whereas previously uses the BlueLogger and RegLogger classes instead. This update also has an additional car. The first car logs in cyan color and the second car logs in magenta, and both cars logs low fuel in yellow.
Below is the screen shot of the output of the running application.
![Screenshot from 2022-10-28 23-58-26](https://user-images.githubusercontent.com/10718290/198813280-694b85f4-b55e-44ad-9ce9-c947626bd3f1.png)
